### PR TITLE
fix widgets.py for Django >= 2.1:

### DIFF
--- a/DjangoUeditor/widgets.py
+++ b/DjangoUeditor/widgets.py
@@ -9,6 +9,7 @@ from . import settings as USettings
 from .commands import *
 from django.utils.six import string_types
 
+
 # 修正输入的文件路径,输入路径的标准格式：abc,不需要前后置的路径符号
 # 如果输入的路径参数是一个函数则执行，否则可以拉接受时间格式化，用来生成如file20121208.bmp的重命名格式
 
@@ -28,8 +29,9 @@ def calc_path(OutputPath, instance=None):
 
     return OutputPath
 
+
 # width=600, height=300, toolbars="full", imagePath="", filePath="", upload_settings={},
-    # settings={},command=None,event_handler=None
+# settings={},command=None,event_handler=None
 
 
 class UEditorWidget(forms.Textarea):
@@ -127,7 +129,7 @@ class UEditorWidget(forms.Textarea):
         except:
             pass
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         # 传入模板的参数


### PR DESCRIPTION
def render(self, name, value, attrs=None):
# 修改为
def render(self, name, value, attrs=None, renderer=None):

原因：Support for Widget.render() methods without the renderer argument is removed.
https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1